### PR TITLE
Add seeder for macpro-la shop access

### DIFF
--- a/database/seeders/MacProLaSeeder.php
+++ b/database/seeders/MacProLaSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Shop;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+class MacProLaSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $shop = Shop::firstOrCreate(
+          ['name' => 'macpro-la.myshopify.com'],
+          [
+            'api_key' => 'PLACEHOLDER',
+          ]
+        );
+
+        User::firstWhere('email', 'dylan@getverdict.com')->shops()->attach($shop);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `MacProLaSeeder` to grant `dylan@getverdict.com` access to `macpro-la.myshopify.com`
- Creates the shop record with a placeholder API key (needs to be replaced before running)

## Test plan
- [ ] Replace `PLACEHOLDER` API key with real key
- [ ] Run `php artisan db:seed --class=MacProLaSeeder`
- [ ] Verify shop record created and user access granted

🤖 Generated with [Claude Code](https://claude.com/claude-code)