### PR TITLE
Add seeder for Real ID Prod Ext shop access

### DIFF
--- a/database/seeders/RealIdProdExtSeeder.php
+++ b/database/seeders/RealIdProdExtSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Shop;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+class RealIdProdExtSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $shop = Shop::firstOrCreate(
+          ['name' => 'PLACEHOLDER', 'api_key' => 'PLACEHOLDER'],
+          [
+            'title' => 'Real ID Prod Ext',
+          ]
+        );
+
+        User::firstWhere('email', 'dylan@getverdict.com')->shops()->attach($shop);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `RealIdProdExtSeeder` to provision the "Real ID Prod Ext" shop and attach `dylan@getverdict.com` to it
- Follows the `RealIdBcDevSeeder` pattern — `name` and `api_key` are `PLACEHOLDER` and must be filled in before running

## Test plan
- [ ] Replace `PLACEHOLDER` values with real shop subdomain and API key
- [ ] Run `php artisan db:seed --class=RealIdProdExtSeeder`
- [ ] Verify the shop is created with title "Real ID Prod Ext" and attached to the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)