### PR TITLE
Add JS SDK section to Dev Tools settings

### DIFF
--- a/resources/js/Components/Settings/DevTools/JsSdkSettings.tsx
+++ b/resources/js/Components/Settings/DevTools/JsSdkSettings.tsx
@@ -1,0 +1,83 @@
+import Card from '@/Components/Card';
+import CodeBlock from '@/Components/CodeBlock';
+
+interface JsSdkSettingsProps {
+    shop: {
+        api_key?: string;
+        licenseKey?: string;
+    };
+}
+
+export default function JsSdkSettings({ shop }: JsSdkSettingsProps) {
+    const apiToken = shop.licenseKey || shop.api_key || '';
+
+    const installSnippet = `<script type="text/javascript" src="https://www.idv.link/assets/index.js"></script>
+<div id="real-id-mount"></div>
+<script>
+  RealID.createFlow({
+    target: "#real-id-mount",
+    mode: "full",
+    apiKey: "${apiToken || 'YOUR_API_TOKEN'}"
+  });
+</script>`;
+
+    return (
+        <Card title="JavaScript SDK">
+            <p className="text-sm text-gray-500 mb-6">
+                Embed an ID check flow directly into your own site or app
+                with the Real ID JavaScript SDK. Drop the script tag in your
+                page, mount the flow to any element, and Real ID handles the
+                rest.
+            </p>
+
+            <div className="space-y-6">
+                <div>
+                    <h3 className="text-lg font-medium text-gray-900 mb-4">
+                        Install
+                    </h3>
+                    <p className="text-sm text-gray-500 mb-4">
+                        Copy and paste this snippet into the page where you
+                        want the ID check flow to appear.
+                    </p>
+                    <CodeBlock code={installSnippet} />
+                </div>
+
+                <div className="border-t border-gray-200 pt-6">
+                    <h3 className="text-lg font-medium text-gray-900 mb-4">
+                        Resources
+                    </h3>
+                    <ul className="space-y-2 text-sm">
+                        <li>
+                            <a
+                                href="https://getverdict.com/help/docs/js"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-600 hover:text-blue-800 underline"
+                            >
+                                JS SDK reference docs
+                            </a>
+                            <span className="text-gray-500">
+                                {' '}
+                                — full configuration options and event hooks.
+                            </span>
+                        </li>
+                        <li>
+                            <a
+                                href="https://getverdict.com/help/sdk-playground"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-600 hover:text-blue-800 underline"
+                            >
+                                SDK playground
+                            </a>
+                            <span className="text-gray-500">
+                                {' '}
+                                — try the SDK live before wiring it up.
+                            </span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </Card>
+    );
+}

--- a/resources/js/Components/Settings/DevTools/JsSdkSettings.tsx
+++ b/resources/js/Components/Settings/DevTools/JsSdkSettings.tsx
@@ -1,5 +1,8 @@
 import Card from '@/Components/Card';
 import CodeBlock from '@/Components/CodeBlock';
+import CopyButton from '@/Components/CopyButton';
+import InputLabel from '@/Components/InputLabel';
+import TextInput from '@/Components/TextInput';
 
 interface JsSdkSettingsProps {
     shop: {
@@ -32,6 +35,24 @@ export default function JsSdkSettings({ shop }: JsSdkSettingsProps) {
 
             <div className="space-y-6">
                 <div>
+                    <InputLabel value="Public Key" />
+                    <div className="mt-1 flex rounded-md shadow-sm">
+                        <TextInput
+                            value={apiToken}
+                            readOnly
+                            className="flex-1 font-mono text-sm"
+                        />
+                        <CopyButton
+                            text={apiToken}
+                            className="ml-2 border border-gray-300 rounded-md"
+                        />
+                    </div>
+                    <p className="mt-1 text-sm text-gray-500">
+                        Pass this as the <code className="bg-gray-100 px-1 py-0.5 rounded">apiKey</code> when initializing the SDK. Safe to embed in client-side code.
+                    </p>
+                </div>
+
+                <div className="border-t border-gray-200 pt-6">
                     <h3 className="text-lg font-medium text-gray-900 mb-4">
                         Install
                     </h3>

--- a/resources/js/Components/Settings/DevTools/index.tsx
+++ b/resources/js/Components/Settings/DevTools/index.tsx
@@ -1,4 +1,5 @@
 import ApiSettings from './ApiSettings';
+import JsSdkSettings from './JsSdkSettings';
 import WebhookSettings from './WebhookSettings';
 
 interface DevToolsProps {
@@ -24,6 +25,7 @@ export default function DevTools({
     return (
         <div className="space-y-6">
             <ApiSettings shop={shop} />
+            <JsSdkSettings shop={shop} />
             <WebhookSettings data={data} setData={setData} errors={errors} />
         </div>
     );


### PR DESCRIPTION
## Summary
- New `JsSdkSettings` component rendered in the Settings → Dev Tools tab, between the API and Webhook sections
- Copy-paste install snippet using the CDN script (`https://www.idv.link/assets/index.js`) and `RealID.createFlow` init, with the shop's API token pre-filled
- Links to the JS SDK reference docs (`https://getverdict.com/help/docs/js`) and the SDK playground (`https://getverdict.com/help/sdk-playground`)

## Test plan
- [ ] Load Settings → Dev Tools and confirm the new "JavaScript SDK" card renders between API and Webhooks
- [ ] Confirm the snippet shows the current shop's `apiKey` (or `YOUR_API_TOKEN` when missing) and the copy button works
- [ ] Click both resource links and confirm they open the docs and playground in a new tab
- [ ] Verify `apiKey` is the correct SDK option — the snippet was inferred from the docs; rename if the SDK uses a different field

🤖 Generated with [Claude Code](https://claude.com/claude-code)