### PR TITLE
Add seeder for Midwest Gunworks Dev shop access

### DIFF
--- a/database/seeders/MidwestGunworksDevSeeder.php
+++ b/database/seeders/MidwestGunworksDevSeeder.php
@@ -23,5 +23,22 @@ class MidwestGunworksDevSeeder extends Seeder
         );
 
         User::firstWhere('email', 'dylan@getverdict.com')->shops()->attach($shop);
+
+        $newUsers = [
+            ['name' => 'Dave', 'email' => 'dave@midwestgunworks.com'],
+            ['name' => 'Bens', 'email' => 'bens@midwestgunworks.com'],
+        ];
+
+        foreach ($newUsers as $attrs) {
+            $user = User::firstOrCreate(
+                ['email' => $attrs['email']],
+                [
+                    'name' => $attrs['name'],
+                    'password' => Hash::make('password'),
+                ]
+            );
+
+            $user->shops()->syncWithoutDetaching([$shop->id]);
+        }
     }
 }

--- a/database/seeders/MidwestGunworksDevSeeder.php
+++ b/database/seeders/MidwestGunworksDevSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Shop;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+class MidwestGunworksDevSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $shop = Shop::firstOrCreate(
+          ['name' => 'PLACEHOLDER', 'api_key' => 'PLACEHOLDER'],
+          [
+            'title' => 'Midwest Gunworks Dev',
+          ]
+        );
+
+        User::firstWhere('email', 'dylan@getverdict.com')->shops()->attach($shop);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `MidwestGunworksDevSeeder` to provision the "Midwest Gunworks Dev" shop and attach `dylan@getverdict.com` via the `shop_user` pivot
- Follows the `RealIdBcDevSeeder` / `RealIdProdExtSeeder` pattern — `name` and `api_key` are `PLACEHOLDER` and must be filled in before running
- Note: the `shop_user` pivot has no role column, so attaching is the only way to grant access — there's no separate "staff" concept in this app

## Test plan
- [ ] Replace `PLACEHOLDER` values with real shop subdomain and API key
- [ ] Run `php artisan db:seed --class=MidwestGunworksDevSeeder`
- [ ] Verify the shop is created with title "Midwest Gunworks Dev" and dylan@getverdict.com appears on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)