### PR TITLE
Show test mode banner when shop is in sandbox

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Inertia\Middleware;
 use Tighten\Ziggy\Ziggy;
 
@@ -47,11 +48,17 @@ class HandleInertiaRequests extends Middleware
         $shops = [];
       }
 
+      $currentShopPayload = null;
+      if ($shop) {
+          $currentShopPayload = $shop->toArray();
+          $currentShopPayload['sandboxMode'] = $this->fetchSandboxMode($shop);
+      }
+
         return [
             ...parent::share($request),
             'auth' => [
                 'user' => $request->user(),
-                'currentShop' => $shop,
+                'currentShop' => $currentShopPayload,
                 'shops' => $shops,
             ],
             'context' => [
@@ -65,5 +72,23 @@ class HandleInertiaRequests extends Middleware
                 'status' => $request->session()->get('status'),
             ],
         ];
+    }
+
+    /**
+     * Fetch the upstream shop's sandboxMode flag, cached briefly so the
+     * shared-prop middleware doesn't hit the core API on every request.
+     */
+    private function fetchSandboxMode($shop): bool
+    {
+        return Cache::remember("shop:{$shop->id}:sandbox_mode", 30, function () use ($shop) {
+            try {
+                $response = $shop->api()->request('GET', 'shop');
+                $body = json_decode($response->getBody(), true) ?? [];
+                return (bool) ($body['sandboxMode'] ?? false);
+            } catch (\Throwable $e) {
+                \Log::warning("Failed to fetch sandboxMode for shop {$shop->id}: {$e->getMessage()}");
+                return false;
+            }
+        });
     }
 }

--- a/resources/js/Layouts/AuthenticatedLayout.tsx
+++ b/resources/js/Layouts/AuthenticatedLayout.tsx
@@ -229,6 +229,12 @@ export default function Authenticated({
                 </div>
             </nav>
 
+            {currentShop?.sandboxMode && (
+                <div className="bg-orange-500 py-1.5 text-center text-sm font-medium text-white">
+                    Test mode — checks created here are not billed
+                </div>
+            )}
+
             {header && (
                 <header className="bg-white shadow">
                     <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">

--- a/resources/js/Layouts/AuthenticatedLayout.tsx
+++ b/resources/js/Layouts/AuthenticatedLayout.tsx
@@ -230,8 +230,16 @@ export default function Authenticated({
             </nav>
 
             {currentShop?.sandboxMode && (
-                <div className="bg-orange-500 py-1.5 text-center text-sm font-medium text-white">
-                    Test mode — checks created here are not billed
+                <div className="bg-orange-500 py-1.5 text-center text-sm text-white">
+                    <strong>Test Mode</strong> — Unlimited free checks, mocked results.{' '}
+                    <a
+                        href="https://getverdict.com/help/docs/getting-started/test-mode"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline hover:text-orange-100"
+                    >
+                        More details
+                    </a>
                 </div>
             )}
 


### PR DESCRIPTION
## Summary
- Adds a thin orange stripe to `AuthenticatedLayout` between the nav and the page header, shown only when `currentShop.sandboxMode` is truthy
- Wires `sandboxMode` into the shared `auth.currentShop` Inertia prop by fetching the upstream Real ID core `/shop` endpoint inside `HandleInertiaRequests`
- Wraps the fetch in `Cache::remember(..., 30, ...)` keyed by shop id, so the middleware doesn't hit the core API on every page load
- Fails closed: any error fetching upstream logs a warning and treats the shop as not-sandbox, so a flaky core API never breaks the dashboard

## Test plan
- [ ] Sign in to a shop where the upstream `/shop` returns `sandboxMode: true` and confirm the orange "Test mode" stripe renders between nav and header
- [ ] Sign in to a non-sandbox shop and confirm no banner
- [ ] Flip the upstream flag and confirm the banner appears/disappears within ~30s (cache TTL)
- [ ] Kill the upstream API and confirm the dashboard still loads (banner just doesn't appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)